### PR TITLE
feat: add search back in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Added 'apply now' button for Synchrony financing [f345d9a]()
 
+##### Bug Fix
+
+- Using a search proxy to help defray cost of [instasearch](https://github.com/algolia/react-instantsearch) sending empty search requests. Used [conditional requests](https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-requests/react/)
+
 ### September 2020
 
 ##### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ##### Features
 
-- Added 'apply now' button for Synchrony financing [f345d9a]()
+- Added 'apply now' button for Synchrony financing [f345d9a](https://github.com/wildpow/new-esc-gatsby/commit/f345d9a54df1a146cbf1f4653a2f9c9b8af4d593)
 
 ##### Bug Fix
 
-- Using a search proxy to help defray cost of [instasearch](https://github.com/algolia/react-instantsearch) sending empty search requests. Used [conditional requests](https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-requests/react/)
+- Using a search proxy to help defray cost of [instasearch](https://github.com/algolia/react-instantsearch) sending empty search requests. Used [conditional requests](https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-requests/react/) PR [126](https://github.com/wildpow/new-esc-gatsby/pull/126)
 
 ### September 2020
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -144,15 +144,14 @@ const cfg = {
         },
       },
     },
-    // TODO add back when search is fixed
-    // {
-    //   resolve: `gatsby-plugin-algolia`,
-    //   options: {
-    //     appId: process.env.GATSBY_ALGOLIA_APP_ID,
-    //     apiKey: process.env.GATSBY_ALGOLIA_ADMIN,
-    //     queries: require("./src/utils/algolia-queries"),
-    //   },
-    // },
+    {
+      resolve: `gatsby-plugin-algolia`,
+      options: {
+        appId: process.env.GATSBY_ALGOLIA_APP_ID,
+        apiKey: process.env.GATSBY_ALGOLIA_ADMIN,
+        queries: require("./src/utils/algolia-queries"),
+      },
+    },
     `gatsby-plugin-remove-serviceworker`,
     `gatsby-plugin-netlify`,
     {

--- a/src/components/Layout/Header/NavIcons.jsx
+++ b/src/components/Layout/Header/NavIcons.jsx
@@ -10,9 +10,9 @@ import Map from "../../../assets/directions-solid.svg";
 import { iconEntry, numberEntry } from "../../../utils/keyframes";
 import { colors, dimensions, breakpoints, fonts } from "../../../utils/styles";
 import CartIcon from "../../../assets/shopping-cart-solid.svg";
-// TODO add back when search is fixed
-// import Search from "../../Search";
-// const searchIndices = [{ name: `Products`, title: `Products` }];
+import Search from "../../Search";
+
+const searchIndices = [{ name: `Products`, title: `Products` }];
 
 // TODO Change name or combine and import from different file to avoid
 // TODO duplication in Cart component.
@@ -131,11 +131,10 @@ const StyledLinks = styled.a`
     color: ${colors.gray["600"]};
   }
 `;
-// TODO Add back when search is fixed
 const ContactUS = styled(StyledLinks)`
-  /* @media (max-width: 360px) {
+  @media (max-width: 360px) {
     display: none;
-  } */
+  }
 `;
 const NavIcons = ({
   pin,
@@ -154,13 +153,12 @@ const NavIcons = ({
   );
   return (
     <ExtraNavRoot>
-      {/* Add back when search is fixed */}
-      {/* <Search
+      <Search
         pin={pin}
         indices={searchIndices}
         searchFocus={searchFocus}
         setSearchFocus={setSearchFocus}
-      /> */}
+      />
       <StyledLinks
         href="tel:1-425-512-0017"
         pin={pin}

--- a/src/components/Layout/MobileMenu/MobileMenu.jsx
+++ b/src/components/Layout/MobileMenu/MobileMenu.jsx
@@ -16,7 +16,10 @@ const MobileMenuRoot = styled.div`
   display: ${({ pin }) => (pin ? "initial" : "none")};
   background: ${colors.blue["900"]};
   bottom: 0;
-  opacity: ${({ searchFocus }) => (searchFocus ? 0 : 1)};
+  /* @media (max-width: 768px) {
+    opacity: ${({ searchFocus }) => (searchFocus ? 0 : 1)};
+  } */
+  /* opacity: ${({ searchFocus }) => (searchFocus ? 0 : 1)}; */
   position: fixed;
   right: 0;
   /* top: -1px; */
@@ -72,6 +75,7 @@ const MobileMenuRoot = styled.div`
 
     display: none;
   }
+  z-index: ${({ searchFocus }) => (searchFocus ? 0 : 10)};
 `;
 
 const Heading = styled.header`

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -7,14 +7,32 @@ import StyledSearchResult from "./styled-search-result";
 import StyledSearchRoot from "./styled-search-root";
 import { useKeyboardEvent, useOnClickOutside } from "../Hooks";
 
+const algoliaClient = algoliasearch(
+  process.env.GATSBY_ALGOLIA_APP_ID,
+  process.env.GATSBY_ALGOLIA_SEARCH,
+);
+
+const searchClient = {
+  search(requests) {
+    if (requests.every(({ params }) => !params.query)) {
+      return Promise.resolve({
+        results: requests.map(() => ({
+          hits: [],
+          nbHits: 0,
+          nbPages: 0,
+          processingTimeMS: 0,
+        })),
+      });
+    }
+
+    return algoliaClient.search(requests);
+  },
+};
+
 export default function Search({ indices, pin, searchFocus, setSearchFocus }) {
   const rootRef = createRef();
   const [query, setQuery] = useState();
   // const [hasFocus, setFocus] = useState(false);
-  const searchClient = algoliasearch(
-    process.env.GATSBY_ALGOLIA_APP_ID,
-    process.env.GATSBY_ALGOLIA_SEARCH,
-  );
   useEffect(() => {
     if (pin === false) setSearchFocus(false);
   }, [searchFocus, pin, setSearchFocus]);

--- a/src/components/Search/search-box.js
+++ b/src/components/Search/search-box.js
@@ -17,16 +17,17 @@ const SearchButton = styled.button`
   width: ${dimensions.headerHeight};
   padding: 0;
   background: ${({ hasFocus }) => (hasFocus ? colors.red[800] : "transparent")};
-  animation: ${iconEntry} 0.75s ease forwards;
+  /* animation: ${iconEntry} 0.75s ease forwards; */
   :focus {
     box-shadow: 0 0 0 1px ${colors.blue["300"]} inset;
     outline: 0;
     transition: box-shadow 0.15s ease-in-out;
   }
+  transition: all 0.2s ease;
 
   :hover {
+    transform: ${({ hasFocus }) => (hasFocus ? "scale(1.0)" : "scale(1.2)")};
     .searchIcon {
-      transform: scale(1.2);
       color: ${colors.blue["900"]};
     }
     .closeIcon {
@@ -36,7 +37,7 @@ const SearchButton = styled.button`
   .closeIcon,
   .searchIcon {
     height: 31px;
-    transition: all 0.2s ease;
+    /* transition: all 0.2s ease; */
     /* transition: transform 0.2s ease; */
     margin: 0;
     width: 31px;
@@ -45,10 +46,12 @@ const SearchButton = styled.button`
   .searchIcon {
     display: ${({ pin }) => (pin ? "initial" : "none")};
     color: ${({ hasFocus }) => (!hasFocus ? colors.gray["600"] : colors.white)};
+    animation: ${iconEntry} 0.75s ease forwards;
   }
   .closeIcon {
     /* animation: ${iconEntry} 0.75s ease forwards;
     transition: all 0.2s ease; */
+    transition: all 0.2s ease;
 
     color: white;
   }

--- a/src/components/Search/styled-search-box.js
+++ b/src/components/Search/styled-search-box.js
@@ -4,6 +4,7 @@ import { colors, dimensions, fonts } from "../../utils/styles";
 
 const open = css`
   width: calc(100% - 60px);
+  width: 100%;
   background: ${colors.gray[100]};
   cursor: text;
   padding-left: 1.6em;


### PR DESCRIPTION
Went over the [Algolia](https://www.algolia.com/) free plan in 4 days. 96% of searches were `empty` due to [instasearch](https://github.com/algolia/react-instantsearch) sending an empty API request when focus is applied to the search box. This helps warm up the connection and cache results page but, also makes their free tier unusable for even small scale projects. Using the [conditional requests](https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-requests/react/) section from their docs should help with this. It introduces some notable lag when display search results but, is worth not having a $70+ bill.